### PR TITLE
rename purge_tags_header config to cache_tags_header

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,20 @@ passing an array of `$options` in the constructor:
   **Type**: `int`
   **Default**: `500`
 
-* **purge_tags_header**: The HTTP header name used to check for tags
+* **cache_tags_header**: The HTTP header name used to check for tags
 
   **Type**: `string`
   **Default**: `Cache-Tags`
 
+### Cache Tagging
+
+Tag cache entries by adding a response header with the tags as a comma 
+separated value. By default, that header is called `Cache-Tags`, this can be
+overwritten in `cache_tags_header`.
+
+To invalidate tags, call the method `Psr6Store::invalidateTags` or use the
+`PurgeTagsListener` from the [FOSHttpCache][3] library to handle tag 
+invalidation requests.
 
 ### WARNING
 

--- a/src/Psr6Store.php
+++ b/src/Psr6Store.php
@@ -94,7 +94,8 @@ final class Psr6Store implements StoreInterface
      *                      Type: int
      *                      Default: 500
      *
-     * - purge_tags_header: The HTTP header name used to check for tags
+     * - cache_tags_header: Name of HTTP header containing a comma separated
+     *                      list of tags to tag the response with.
      *
      *                      Type: string
      *                      Default: Cache-Tags
@@ -111,8 +112,8 @@ final class Psr6Store implements StoreInterface
         $resolver->setDefault('prune_threshold', 500)
             ->setAllowedTypes('prune_threshold', 'int');
 
-        $resolver->setDefault('purge_tags_header', 'Cache-Tags')
-            ->setAllowedTypes('purge_tags_header', 'string');
+        $resolver->setDefault('cache_tags_header', 'Cache-Tags')
+            ->setAllowedTypes('cache_tags_header', 'string');
 
         $resolver->setDefault('cache', function (Options $options) {
             if (!isset($options['cache_directory'])) {
@@ -231,8 +232,8 @@ final class Psr6Store implements StoreInterface
 
         // Tags
         $tags = [];
-        if ($response->headers->has($this->options['purge_tags_header'])) {
-            $tags = explode(',', $response->headers->get($this->options['purge_tags_header']));
+        if ($response->headers->has($this->options['cache_tags_header'])) {
+            $tags = explode(',', $response->headers->get($this->options['cache_tags_header']));
         }
 
         // Prune expired entries on file system if needed
@@ -356,13 +357,14 @@ final class Psr6Store implements StoreInterface
 
     /**
      * Remove/Expire cache objects based on cache tags.
-     * Returns true on success and false otherwise.
+     *
+     * The tags are set from the header configured in cache_tags_header.
      *
      * @param array $tags Tags that should be removed/expired from the cache
      *
      * @throws \RuntimeException if incompatible cache adapter provided
      *
-     * @return bool
+     * @return bool true on success, false otherwise
      */
     public function invalidateTags(array $tags)
     {


### PR DESCRIPTION
great job, really like this!

looking over the thing, i noticed that i would prefer this name for the config. the meaning of the header is cache tags, not purging.

also added a bit more explanation for the tagging.

a note on the default header name: these days, the recommendation is to omit the `X-` from custom headers. but for FOSHttpCache we in the end decided its too much hassle for too little benefit to refactor everything to drop them. this means that the default value will not work, because we still use `X-Cache-Tags`. but i think we can handle this in the doc. its better if you have a clean thing here in this new library.