### PR TITLE
Add symfony 5.0 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 .php_cs.cache
+.phpunit.result.cache
 composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
 
 script:
   - if [[ $COVERAGE ]]; then mkdir -p build/logs; fi
-  - php vendor/bin/simple-phpunit $COVERAGE
+  - php bin/phpunit $COVERAGE
 
 after_script:
  - if [[ $COVERAGE ]]; then php vendor/bin/php-coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,12 @@ matrix:
       env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
     - php: 7.4snapshot
     - php: 7.4snapshot
+      env: COMPOSER_DEV_STABILITY=true
+    - php: 7.4snapshot
       env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
     - php: nightly
+    - php: nightly
+      env: COMPOSER_DEV_STABILITY=true
     - php: nightly
       env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
   allow_failures:
@@ -31,6 +35,7 @@ before_script:
     if [ "$TRAVIS_PHP_VERSION" = "nightly" ]; then
       COMPOSER_FLAGS="$COMPOSER_FLAGS --ignore-platform-reqs"
     fi;
+  - if [[ $COMPOSER_DEV_STABILITY = true ]]; then composer config minimum-stability dev ; fi
   - travis_wait composer update --no-interaction $COMPOSER_FLAGS
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
 
 script:
   - if [[ $COVERAGE ]]; then mkdir -p build/logs; fi
-  - php vendor/bin/phpunit $COVERAGE
+  - php vendor/bin/simple-phpunit $COVERAGE
 
 after_script:
  - if [[ $COVERAGE ]]; then php vendor/bin/php-coveralls; fi

--- a/bin/phpunit
+++ b/bin/phpunit
@@ -1,0 +1,13 @@
+#!/usr/bin/env php
+<?php
+
+if (!file_exists(dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-phpunit.php')) {
+    echo "Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`.\n";
+    exit(1);
+}
+
+if (false === getenv('SYMFONY_PHPUNIT_VERSION') && PHP_VERSION_ID >= 70100) {
+    putenv('SYMFONY_PHPUNIT_VERSION=7.5');
+}
+
+require dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-phpunit.php';

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.12",
-        "symfony/phpunit-bridge": "dev-master",
+        "symfony/phpunit-bridge": "^4.3.5",
         "php-coveralls/php-coveralls": "^2.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
     ],
     "require": {
         "php": "^5.6|^7.0",
-        "symfony/lock": "^3.4|^4.0",
-        "symfony/cache": "^3.4|^4.0",
-        "symfony/http-foundation": "^3.0|^4.0",
-        "symfony/http-kernel": "^3.0|^4.0",
-        "symfony/options-resolver": "^3.0|^4.0"
+        "symfony/lock": "^3.4|^4.0|^5.0",
+        "symfony/cache": "^3.4|^4.0|^5.0",
+        "symfony/http-foundation": "^3.0|^4.0|^5.0",
+        "symfony/http-kernel": "^3.0|^4.0|^5.0",
+        "symfony/options-resolver": "^3.0|^4.0|^5.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.12",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.12",
-        "phpunit/phpunit": "^5.7.27",
+        "symfony/phpunit-bridge": "dev-master",
         "php-coveralls/php-coveralls": "^2.1"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
 >
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,9 @@
          stopOnFailure="false"
          bootstrap="vendor/autoload.php"
 >
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
+    </php>
     <testsuites>
         <testsuite name="PSR-6 HttpCache Store Test Suite">
             <directory>./tests/</directory>

--- a/src/Psr6Store.php
+++ b/src/Psr6Store.php
@@ -146,9 +146,11 @@ class Psr6Store implements Psr6StoreInterface
             $defaultLockStore = $this->getDefaultLockStore($options['cache_directory']);
 
             if (class_exists(LockFactory::class)) {
+                // Symfony >= 4.4
                 return new LockFactory($defaultLockStore);
             }
 
+            // Symfony < 4.4
             return new Factory($defaultLockStore);
         })->setAllowedTypes('lock_factory', [Factory::class, LockFactory::class]);
 
@@ -254,7 +256,14 @@ class Psr6Store implements Psr6StoreInterface
         // Tags
         $tags = [];
         if ($response->headers->has($this->options['cache_tags_header'])) {
-            foreach ($response->headers->get($this->options['cache_tags_header'], '', false) as $header) {
+            // Symfony < 4.4
+            $headers = $response->headers->get($this->options['cache_tags_header'], '', false);
+            if (is_string($headers)) {
+                // Symfony >= 4.4
+                $headers = $response->headers->all($this->options['cache_tags_header']);
+            }
+
+            foreach ($headers as $header) {
                 foreach (explode(',', $header) as $tag) {
                     $tags[] = $tag;
                 }

--- a/src/Psr6Store.php
+++ b/src/Psr6Store.php
@@ -258,7 +258,7 @@ class Psr6Store implements Psr6StoreInterface
         if ($response->headers->has($this->options['cache_tags_header'])) {
             // Symfony < 4.4
             $headers = $response->headers->get($this->options['cache_tags_header'], '', false);
-            if (is_string($headers)) {
+            if (\is_string($headers)) {
                 // Symfony >= 4.4
                 $headers = $response->headers->all($this->options['cache_tags_header']);
             }

--- a/tests/Psr6StoreTest.php
+++ b/tests/Psr6StoreTest.php
@@ -13,6 +13,7 @@ namespace Toflar\Psr6HttpCacheStore;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
@@ -31,17 +32,19 @@ use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 
 class Psr6StoreTest extends TestCase
 {
+    use SetUpTearDownTrait;
+
     /**
      * @var Psr6Store
      */
     private $store;
 
-    protected function setUp()
+    protected function doSetUp()
     {
         $this->store = new Psr6Store(['cache_directory' => sys_get_temp_dir()]);
     }
 
-    protected function tearDown()
+    protected function doTearDown()
     {
         $this->getCache()->clear();
         $this->store->cleanup();
@@ -226,7 +229,7 @@ class Psr6StoreTest extends TestCase
 
         $entries = $cacheItem->get();
 
-        $this->assertInternalType('array', $entries, 'Entries are stored in cache.');
+        $this->assertTrue(is_array($entries), 'Entries are stored in cache.');
         $this->assertCount(1, $entries, 'One entry is stored.');
         $this->assertSame($entries[Psr6Store::NON_VARYING_KEY]['headers'], array_diff_key($response->headers->all(), ['age' => []]), 'Response headers are stored with no age header.');
     }
@@ -390,7 +393,7 @@ class Psr6StoreTest extends TestCase
         // Cookies match
         $request = Request::create('https://foobar.com/', 'GET', [], ['Foo' => 'Bar'], [], ['HTTP_COOKIE' => 'Foo=Bar']);
         $response = new Response('hello world', 200, ['Vary' => 'Cookie']);
-        $response->headers->setCookie(new Cookie('Foo', 'Bar'));
+        $response->headers->setCookie(new Cookie('Foo', 'Bar', 0, '/', false, null, true, false, null));
 
         $this->store->write($request, $response);
 

--- a/tests/Psr6StoreTest.php
+++ b/tests/Psr6StoreTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Lock\Exception\LockReleasingException;
 use Symfony\Component\Lock\Factory;
+use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 
@@ -63,7 +64,7 @@ class Psr6StoreTest extends TestCase
         $cache = $this->createMock(TagAwareAdapterInterface::class);
         $cache->expects($this->once())
             ->method('deleteItem');
-        $lockFactory = $this->createMock(Factory::class);
+        $lockFactory = $this->createFactoryMock();
 
         $store = new Psr6Store([
             'cache' => $cache,
@@ -553,7 +554,7 @@ class Psr6StoreTest extends TestCase
             ->method('release')
             ->willReturn(true);
 
-        $lockFactory = $this->createMock(Factory::class);
+        $lockFactory = $this->createFactoryMock();
         $lockFactory
             ->expects($this->any())
             ->method('createLock')
@@ -622,7 +623,7 @@ class Psr6StoreTest extends TestCase
             ->method('acquire')
             ->willReturn(false);
 
-        $lockFactory = $this->createMock(Factory::class);
+        $lockFactory = $this->createFactoryMock();
         $lockFactory
             ->expects($this->any())
             ->method('createLock')
@@ -665,7 +666,7 @@ class Psr6StoreTest extends TestCase
             ->method('release')
             ->willThrowException(new LockReleasingException());
 
-        $lockFactory = $this->createMock(Factory::class);
+        $lockFactory = $this->createFactoryMock();
         $lockFactory
             ->expects($this->once())
             ->method('createLock')
@@ -690,7 +691,7 @@ class Psr6StoreTest extends TestCase
             ->method('release')
             ->willThrowException(new LockReleasingException());
 
-        $lockFactory = $this->createMock(Factory::class);
+        $lockFactory = $this->createFactoryMock();
         $lockFactory
             ->expects($this->once())
             ->method('createLock')
@@ -726,5 +727,14 @@ class Psr6StoreTest extends TestCase
         $cache->setAccessible(true);
 
         return $cache->getValue($this->store);
+    }
+
+    private function createFactoryMock()
+    {
+        if (class_exists(LockFactory::class)) {
+            return $this->createMock(LockFactory::class);
+        }
+
+        return $this->createMock(Factory::class);
     }
 }

--- a/tests/Psr6StoreTest.php
+++ b/tests/Psr6StoreTest.php
@@ -39,17 +39,6 @@ class Psr6StoreTest extends TestCase
      */
     private $store;
 
-    protected function doSetUp()
-    {
-        $this->store = new Psr6Store(['cache_directory' => sys_get_temp_dir()]);
-    }
-
-    protected function doTearDown()
-    {
-        $this->getCache()->clear();
-        $this->store->cleanup();
-    }
-
     public function testCustomCacheWithoutLockFactory()
     {
         $this->expectException(MissingOptionsException::class);
@@ -229,7 +218,7 @@ class Psr6StoreTest extends TestCase
 
         $entries = $cacheItem->get();
 
-        $this->assertTrue(is_array($entries), 'Entries are stored in cache.');
+        $this->assertTrue(\is_array($entries), 'Entries are stored in cache.');
         $this->assertCount(1, $entries, 'One entry is stored.');
         $this->assertSame($entries[Psr6Store::NON_VARYING_KEY]['headers'], array_diff_key($response->headers->all(), ['age' => []]), 'Response headers are stored with no age header.');
     }
@@ -712,6 +701,17 @@ class Psr6StoreTest extends TestCase
         // This test will fail if an exception is thrown, otherwise we mark it
         // as passed.
         $this->addToAssertionCount(1);
+    }
+
+    protected function doSetUp()
+    {
+        $this->store = new Psr6Store(['cache_directory' => sys_get_temp_dir()]);
+    }
+
+    protected function doTearDown()
+    {
+        $this->getCache()->clear();
+        $this->store->cleanup();
     }
 
     /**

--- a/tests/Psr6StoreTest.php
+++ b/tests/Psr6StoreTest.php
@@ -732,9 +732,11 @@ class Psr6StoreTest extends TestCase
     private function createFactoryMock()
     {
         if (class_exists(LockFactory::class)) {
+            // Symfony >= 4.4
             return $this->createMock(LockFactory::class);
         }
 
+        // Symfony < 4.4
         return $this->createMock(Factory::class);
     }
 }

--- a/tests/Psr6StoreTest.php
+++ b/tests/Psr6StoreTest.php
@@ -13,7 +13,6 @@ namespace Toflar\Psr6HttpCacheStore;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
@@ -32,12 +31,21 @@ use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 
 class Psr6StoreTest extends TestCase
 {
-    use SetUpTearDownTrait;
-
     /**
      * @var Psr6Store
      */
     private $store;
+
+    protected function setUp()
+    {
+        $this->store = new Psr6Store(['cache_directory' => sys_get_temp_dir()]);
+    }
+
+    protected function tearDown()
+    {
+        $this->getCache()->clear();
+        $this->store->cleanup();
+    }
 
     public function testCustomCacheWithoutLockFactory()
     {
@@ -701,17 +709,6 @@ class Psr6StoreTest extends TestCase
         // This test will fail if an exception is thrown, otherwise we mark it
         // as passed.
         $this->addToAssertionCount(1);
-    }
-
-    protected function doSetUp()
-    {
-        $this->store = new Psr6Store(['cache_directory' => sys_get_temp_dir()]);
-    }
-
-    protected function doTearDown()
-    {
-        $this->getCache()->clear();
-        $this->store->cleanup();
     }
 
     /**


### PR DESCRIPTION
Fix compatibility to symfony 5.0.

**Needs**:

 - [x] symfony/symfony#34036

**TODO**:

- [x] Use `symfony/phpunit-bridge` to use correct PhpUnit version for PHP version to run not into prefer lowest errors caused by phpunit
- [x] `1x: The default value of the "$secure" and "$samesite" arguments of "Symfony\Component\HttpFoundation\Cookie::__construct"'s constructor will respectively change from "false" to "null" and from "null" to "lax" in Symfony 5.0, you should define their values explicitly or use "Cookie::create()" instead.
    1x in Psr6StoreTest::testLookupWithVaryOnCookies from Toflar\Psr6HttpCacheStore`
 - [x] `Element 'phpunit', attribute 'syntaxCheck': The attribute 'syntaxCheck' is not allowed`