### PR TITLE
Add test for hit after expired should refresh cache

### DIFF
--- a/tests/Psr6StoreTest.php
+++ b/tests/Psr6StoreTest.php
@@ -891,46 +891,6 @@ class Psr6StoreTest extends TestCase
         ];
     }
 
-
-    public function testSymfonyFileSystemTagAwareAdapter()
-    {
-        $cache  = new FilesystemTagAwareAdapter();
-        $cache->clear();
-
-        /** @var CacheItemInterface $cacheItem */
-        $cacheItem = $cache->getItem('test');
-
-        $this->assertFalse($cacheItem->isHit());
-
-        // write cache again
-        $cacheItem->set('test');
-        $cacheItem->tag('1234');
-        $cacheItem->expiresAfter(5);
-
-        $cache->save($cacheItem);
-
-        /** @var CacheItemInterface $cacheItem */
-        $cacheItem = $cache->getItem('test');
-        $this->assertTrue($cacheItem->isHit());
-
-        sleep(5);
-
-        /** @var CacheItemInterface $cacheItem */
-        $cacheItem = $cache->getItem('test');
-
-        $this->assertFalse($cacheItem->isHit());
-
-        // write cache file again
-        $cacheItem->set('test');
-        $cacheItem->tag('1234');
-        $cacheItem->expiresAfter(5);
-
-        $cache->save($cacheItem);
-        /** @var CacheItemInterface $cacheItem */
-        $cacheItem = $cache->getItem('test');
-        $this->assertTrue($cacheItem->isHit());
-    }
-
     public function testHitAfterExpiredWithTags()
     {
         // first request to this resource


### PR DESCRIPTION
After tracking it down it seems to be a symfony/cache issue: https://github.com/symfony/symfony/issues/36458