### PR TITLE
Also unset date header

### DIFF
--- a/src/Psr6Store.php
+++ b/src/Psr6Store.php
@@ -172,7 +172,7 @@ class Psr6Store implements Psr6StoreInterface, ClearableInterface
 
         $cacheKey = $this->getCacheKey($request);
         $headers = $response->headers->all();
-        unset($headers['age']);
+        unset($headers['age'], $headers['date']);
 
         $item = $this->cache->getItem($cacheKey);
 


### PR DESCRIPTION
This PR would fix https://github.com/contao/contao/issues/3016

Browsers will not put a resource in its private cache, if the `Age` response header is greater than the given `max-age` or if the `Date` response header is older than the `max-age`.

Since the `Date` response header is currently also saved into the cache, the resulting response will always contain the `Date` of when the resource was originally put into the public cache, rather than the current time. This will also automatically cause Symfony's `HttpCache` to set an `Age` header that is grater than `0`.

As discussed in Slack with @ausi the `Date` header should always be the current server time, so that the client can use that date to check against `Expires` headers for example. And evidently the client might also use the `Date` when validating the freshness for its private cache.

This PR additionally unsets the `date` header from the response to be saved so that when the cache entry is loaded by the proxy again, the current date is automatically used for the `Date` header instead.