### PR TITLE
Allow usage with Symfony 7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ['8.0', '8.1', '8.2']
+                php: ['8.0', '8.1', '8.2', '8.3']
         steps:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -60,7 +60,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ['8.0', '8.1', '8.2']
+                php: ['8.0', '8.1', '8.2', '8.3']
         steps:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,14 +35,13 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ['8.0', '8.1']
+                php: ['8.0', '8.1', '8.2']
         steps:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
                   extensions: json
-                  tools: prestissimo
                   coverage: none
 
             - name: Checkout
@@ -61,14 +60,13 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ['8.0', '8.1']
+                php: ['8.0', '8.1', '8.2']
         steps:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
                   extensions: json
-                  tools: prestissimo
                   coverage: none
 
             - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -11,18 +11,19 @@
     ],
     "require": {
         "php": "^8.0",
-        "symfony/lock": "^6.0",
-        "symfony/cache": "^6.0",
-        "symfony/http-foundation": "^6.0",
-        "symfony/http-kernel": "^6.0",
-        "symfony/options-resolver": "^6.0"
+        "symfony/lock": "^6.0 || ^7.0",
+        "symfony/cache": "^6.0 || ^7.0",
+        "symfony/http-foundation": "^6.0 || ^7.0",
+        "symfony/http-kernel": "^6.0 || ^7.0",
+        "symfony/options-resolver": "^6.0 || ^7.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^6.0"
+        "symfony/phpunit-bridge": "^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {
             "Toflar\\Psr6HttpCacheStore\\": "src"
         }
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/tests/Psr6StoreTest.php
+++ b/tests/Psr6StoreTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Lock\Exception\LockReleasingException;
 use Symfony\Component\Lock\LockFactory;
-use Symfony\Component\Lock\LockInterface;
+use Symfony\Component\Lock\SharedLockInterface;
 use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 
 class Psr6StoreTest extends TestCase
@@ -661,15 +661,14 @@ class Psr6StoreTest extends TestCase
             ->expects($this->exactly(3))
             ->method('prune');
 
-        $lock = $this->createMock(LockInterface::class);
+        $lock = $this->createMock(SharedLockInterface::class);
         $lock
             ->expects($this->exactly(3))
             ->method('acquire')
             ->willReturn(true);
         $lock
             ->expects($this->exactly(3))
-            ->method('release')
-            ->willReturn(true);
+            ->method('release');
 
         $lockFactory = $this->createMock(LockFactory::class);
         $lockFactory
@@ -734,7 +733,7 @@ class Psr6StoreTest extends TestCase
             ->expects($this->never())
             ->method('prune');
 
-        $lock = $this->createMock(LockInterface::class);
+        $lock = $this->createMock(SharedLockInterface::class);
         $lock
             ->expects($this->exactly(3))
             ->method('acquire')
@@ -777,7 +776,7 @@ class Psr6StoreTest extends TestCase
 
     public function testUnlockReturnsFalseOnLockReleasingException(): void
     {
-        $lock = $this->createMock(LockInterface::class);
+        $lock = $this->createMock(SharedLockInterface::class);
         $lock
             ->expects($this->once())
             ->method('release')
@@ -802,7 +801,7 @@ class Psr6StoreTest extends TestCase
 
     public function testLockReleasingExceptionIsIgnoredOnCleanup(): void
     {
-        $lock = $this->createMock(LockInterface::class);
+        $lock = $this->createMock(SharedLockInterface::class);
         $lock
             ->expects($this->once())
             ->method('release')


### PR DESCRIPTION
Some of the tests did fail and I needed to change the LockInterface to SharedLockInterface and fix the willReturn of release method:

<img width="1555" alt="Bildschirmfoto 2023-09-16 um 13 55 16" src="https://github.com/Toflar/psr6-symfony-http-cache-store/assets/1698337/827e3fc6-05d5-48b6-bcf3-2fc96d6de28a">

On the project code itself there seems to be no changes required to support Symfony 7.0 or PHP 8.3. 