### PR TITLE
Added support for gzipping the cached files

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ passing an array of `$options` in the constructor:
 
   **Type**: `boolean`
   **Default**: `true`
+
+* **gzip_level**: Whether or not content digests should be generated.
+  See "Generating Content Digests" for more information.
+
+  **Type**: `int`
+  **Default**: `9`
   
 ### Generating Content Digests
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ passing an array of `$options` in the constructor:
   deactivate gzipping.
 
   **Type**: `int`
-  **Default**: `9`
+  **Default**: `6`
   
 ### Generating Content Digests
 

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ passing an array of `$options` in the constructor:
   **Type**: `boolean`
   **Default**: `true`
 
-* **gzip_level**: Whether or not content digests should be generated.
-  See "Generating Content Digests" for more information.
+* **gzip_level**: The gzip level to reduce the required cache storage. Use `0` to
+  deactivate gzipping.
 
   **Type**: `int`
   **Default**: `9`

--- a/src/Psr6Store.php
+++ b/src/Psr6Store.php
@@ -466,8 +466,12 @@ class Psr6Store implements Psr6StoreInterface, ClearableInterface
 
     private function gzipResponse(Response $response): void
     {
-        // Not supported or already gzipped
-        if ($response instanceof BinaryFileResponse || !$this->isGzipSupported() || $this->isResponseGzipped($response)) {
+        // Do not gzip if already encoded or not supported
+        if ($response->headers->has('Content-Encoding') ||
+            $response instanceof BinaryFileResponse ||
+            !$this->isGzipSupported() ||
+            $this->isResponseGzipped($response)
+        ) {
             return;
         }
 

--- a/src/Psr6Store.php
+++ b/src/Psr6Store.php
@@ -80,7 +80,7 @@ class Psr6Store implements Psr6StoreInterface, ClearableInterface
         $resolver->setDefault('generate_content_digests', true)
             ->setAllowedTypes('generate_content_digests', 'boolean');
 
-        $resolver->setDefault('gzip_level', 9)
+        $resolver->setDefault('gzip_level', 6)
             ->setAllowedTypes('gzip_level', 'int')
             ->setNormalizer('gzip_level', function (Options $options, int $value): int {
                 if ($value < 0 || $value > 9) {

--- a/tests/Psr6StoreTest.php
+++ b/tests/Psr6StoreTest.php
@@ -650,7 +650,7 @@ class Psr6StoreTest extends TestCase
             'cache' => $cache,
             'lock_factory' => $lockFactory,
             'generate_content_digests' => false,
-            'gzip_level' => 9
+            'gzip_level' => 4
         ]);
 
         $regularRequest = Request::create('https://foobar.com/');
@@ -664,8 +664,8 @@ class Psr6StoreTest extends TestCase
         $cacheItem = $cache->getItem($cacheKey);
         $this->assertTrue($cacheItem->isHit());
 
-        // Should be gzip encoded on level 9
-        $this->assertSame(gzencode('hello world', 9), $cacheItem->get()['non-varying']['content']);
+        // Should be gzip encoded on level 4
+        $this->assertSame(gzencode('hello world', 4), $cacheItem->get()['non-varying']['content']);
 
         // Content should be decoded if we don't support gzip
         $response = $store->lookup(Request::create('https://foobar.com/'));
@@ -674,7 +674,7 @@ class Psr6StoreTest extends TestCase
 
         // Content should be gzip encoded if we support gzip
         $response = $store->lookup($gzipSupportingRequest);
-        $this->assertSame(gzencode('hello world', 9), $response->getContent());
+        $this->assertSame(gzencode('hello world', 4), $response->getContent());
         $this->assertSame('gzip', $response->headers->get('Content-Encoding'));
 
         // Gzipped cache file still exists but for some reason, gzip features are not available on the system anymore
@@ -698,7 +698,7 @@ class Psr6StoreTest extends TestCase
             'cache' => $cache,
             'lock_factory' => $lockFactory,
             'generate_content_digests' => false,
-            'gzip_level' => 9
+            'gzip_level' => 6
         ]);
 
         $request = Request::create('https://foobar.com/');

--- a/tests/Psr6StoreTest.php
+++ b/tests/Psr6StoreTest.php
@@ -29,6 +29,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Lock\Exception\LockReleasingException;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\SharedLockInterface;
+use Symfony\Component\Lock\Store\InMemoryStore;
 use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 
 class Psr6StoreTest extends TestCase
@@ -55,6 +56,16 @@ class Psr6StoreTest extends TestCase
 
         new Psr6Store([
             'cache' => $cache,
+        ]);
+    }
+
+    public function testWrongGzipLevel(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The gzip_level has to be between 0 (disabled) and 9.');
+
+        new Psr6Store([
+            'gzip_level' => 20
         ]);
     }
 
@@ -631,6 +642,54 @@ class Psr6StoreTest extends TestCase
         $this->assertFalse($cacheItem2->isHit());
     }
 
+    public function testGzipHandling(): void
+    {
+        $cache = new ArrayAdapter();
+        $lockFactory = new LockFactory(new InMemoryStore());
+        $store = new Psr6Store([
+            'cache' => $cache,
+            'lock_factory' => $lockFactory,
+            'generate_content_digests' => false,
+            'gzip_level' => 9
+        ]);
+
+        $regularRequest = Request::create('https://foobar.com/');
+        $gzipSupportingRequest = Request::create('https://foobar.com/');
+        $gzipSupportingRequest->headers->set('Accept-Encoding', 'gzip, deflate, br');
+
+        $response = new Response('hello world', 200, ['Cache-Control' => 's-maxage=600, public']);
+        $store->write($regularRequest, $response);
+
+        $cacheKey = $store->getCacheKey($regularRequest);
+        $cacheItem = $cache->getItem($cacheKey);
+        $this->assertTrue($cacheItem->isHit());
+
+        // Should be gzip encoded on level 9
+        $this->assertSame(gzencode('hello world', 9), $cacheItem->get()['non-varying']['content']);
+
+        // Content should be decoded if we don't support gzip
+        $response = $store->lookup(Request::create('https://foobar.com/'));
+        $this->assertSame('hello world', $response->getContent());
+        $this->assertFalse($response->headers->has('Content-Encoding'));
+
+        // Content should be gzip encoded if we support gzip
+        $response = $store->lookup($gzipSupportingRequest);
+        $this->assertSame(gzencode('hello world', 9), $response->getContent());
+        $this->assertSame('gzip', $response->headers->get('Content-Encoding'));
+
+        // Gzipped cache file still exists but for some reason, gzip features are not available on the system anymore
+        // so we cannot decode it anymore - in this case, lookup should work for gzip supporting request but fail for
+        // the regular request as decoding doesn't work.
+        $store = new Psr6Store([
+            'cache' => $cache,
+            'lock_factory' => $lockFactory,
+            'generate_content_digests' => false,
+            'gzip_level' => 0 // Same as not having gzip features available
+        ]);
+        $this->assertInstanceOf(Response::class, $store->lookup($gzipSupportingRequest));
+        $this->assertNull($store->lookup($regularRequest));
+    }
+
     public function testPruneIgnoredIfCacheBackendDoesNotImplementPrunableInterface(): void
     {
         $cache = $this->getMockBuilder(RedisAdapter::class)
@@ -886,6 +945,7 @@ class Psr6StoreTest extends TestCase
         $store = new Psr6Store([
             'cache' => $cache,
             'lock_factory' => $this->createMock(LockFactory::class),
+            'gzip_level' => 0,
         ]);
 
         $response = new Response('foobar', 200, $responseHeaders);


### PR DESCRIPTION
This brings support for gzipped cache files which should significantly reduce the used storage.
If a request supports gzip (`Accept-Encoding`) which should be the majority of all browser, we can deliver the gzipped file right away. If not, we'll decode on the fly.

I think always gzipping is a sensible default but asking for opinions here from the heavy users of this package :)

/cc @alexander-schranz, Sulu
/cc @mnocon, Ibexa (ex. eZ publish)