### PR TITLE
Add support for Symfony 8, require at least PHP 8.1 and add PHP 8.5 to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
 
             -   name: Checkout
                 uses: actions/checkout@v2
-                
+
             - name: Run the CS fixer
               run: php-cs-fixer fix
 
@@ -35,7 +35,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ['8.0', '8.1', '8.2', '8.3']
+                php: ['8.0', '8.1', '8.2', '8.3', '8.4']
         steps:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -46,6 +46,10 @@ jobs:
 
             - name: Checkout
               uses: actions/checkout@v2
+
+            - name: Set composer stability
+              if: ${{ matrix.php == '8.4' }}
+              run: composer config minimum-stability ${{ matrix.composer-stability }}
 
             - name: Install the dependencies
               run: composer install --no-interaction --no-suggest
@@ -60,7 +64,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ['8.0', '8.1', '8.2', '8.3']
+                php: ['8.0', '8.1', '8.2', '8.3', '8.4']
         steps:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,14 @@
     ],
     "require": {
         "php": "^8.0",
-        "symfony/lock": "^6.0 || ^7.0",
-        "symfony/cache": "^6.0 || ^7.0",
-        "symfony/http-foundation": "^6.0 || ^7.0",
-        "symfony/http-kernel": "^6.0 || ^7.0",
-        "symfony/options-resolver": "^6.0 || ^7.0"
+        "symfony/lock": "^6.0 || ^7.0 || ^8.0",
+        "symfony/cache": "^6.0 || ^7.0 || ^8.0",
+        "symfony/http-foundation": "^6.0 || ^7.0 || ^8.0",
+        "symfony/http-kernel": "^6.0 || ^7.0 || ^8.0",
+        "symfony/options-resolver": "^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^6.0 || ^7.0"
+        "symfony/phpunit-bridge": "^6.0 || ^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Test current compatibility to Symfony 8.

Is required: https://github.com/FriendsOfSymfony/FOSHttpCache/pull/597 as CI installs this package.